### PR TITLE
Replace socat

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,25 @@
-FROM alpine:3.17
+FROM debian:bookworm-slim
 
-RUN apk add --no-cache socat docker-cli
+ARG TARGETARCH
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get update \
+ && apt-get install -y --no-install-recommends \
+        curl \
+        gnupg2 \
+        socat \
+        ca-certificates \
+        simpleproxy \
+ && rm -rf /var/lib/apt/lists/* \
+ && apt-get clean
+
+RUN curl -fsSL "https://download.docker.com/linux/debian/gpg" | apt-key add -qq - >/dev/null \
+ && echo "deb [arch=${TARGETARCH}] https://download.docker.com/linux/debian bookworm stable" > /etc/apt/sources.list.d/docker.list \
+ && apt-get update -qq >/dev/null \
+ && apt-get install -y --no-install-recommends docker-ce-cli \
+ && rm -rf /var/lib/apt/lists/* \
+ && apt-get clean
+
+RUN apt update && apt install -y docker-ce-cli simpleproxy
 
 ADD entry.sh /usr/bin/entry.sh
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 IMAGE = fopina/swarm-service-proxy
-VERSION = 5
+VERSION = 6
 
 build:
 	docker build -t ${IMAGE}:test \

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,12 @@
 IMAGE = fopina/swarm-service-proxy
-VERSION = 6
+VERSION = 6-beta
 
 build:
 	docker build -t ${IMAGE}:test \
 				 .
 release:
 	docker buildx build \
-           --platform linux/amd64,linux/arm64,linux/arm/v7 \
+           --platform linux/amd64,linux/arm64 \
            --build-arg VERSION=${VERSION} \
            --push \
            -t ${IMAGE}:${VERSION} \

--- a/entry.sh
+++ b/entry.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 
@@ -21,7 +21,8 @@ if [ -n "${PROXIED_PORT}" ]; then
     if [[ "${PROXIED_PROTO}" == "udp" ]]; then
         socat UDP4-LISTEN:${PROXIED_PORT},fork UDP4:$CIP:${PROXIED_PORT} &
     else
-        socat TCP4-LISTEN:${PROXIED_PORT},fork TCP4:$CIP:${PROXIED_PORT} &
+        # socat TCP4-LISTEN:${PROXIED_PORT},fork TCP4:$CIP:${PROXIED_PORT} &
+        simpleproxy -L ${PROXIED_PORT} -R ${CIP}:${PROXIED_PORT}
     fi
 fi
 


### PR DESCRIPTION
Attempt to fix an issue where container output was not shown when using this image to proxy a DinD container, where the output had `\r` lines (without `\n` - basically a progress bar using `tqdm`).

Testing simpleproxy seems to have made it even worse...
To be seen...

If moving forward, undo debian changes back to alpine and just compile from source like https://github.com/alex88/simpleproxy-docker/